### PR TITLE
allow to store response when code is 400 to 500

### DIFF
--- a/src/main/java/org/joget/marketplace/EnhancedJsonTool.java
+++ b/src/main/java/org/joget/marketplace/EnhancedJsonTool.java
@@ -404,12 +404,13 @@ public class EnhancedJsonTool extends DefaultApplicationPlugin {
             }
 
             String responseType = getPropertyString("responseType");
+            jsonResponse = EntityUtils.toString(response.getEntity(), "UTF-8");
 
             if (!responseType.isEmpty() && response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() <= 300) {
 
                 if (responseType.equalsIgnoreCase("JSON")) {
                     //if(response.getEntity().getContentType().getValue().equalsIgnoreCase("application/json")){
-                    jsonResponse = EntityUtils.toString(response.getEntity(), "UTF-8");
+                    
                     String jsonResponseFormatted = jsonResponse;
                     if (jsonResponseFormatted != null && !jsonResponseFormatted.isEmpty()) {
                         if (jsonResponseFormatted.startsWith("[") && jsonResponseFormatted.endsWith("]")) {


### PR DESCRIPTION
fix for json response is not stored into form when response code is 400 to 500.

Enhanced JSON Tool settings for Store Response Status
![p2](https://github.com/user-attachments/assets/cba24f51-79b3-4dd1-8732-382c0a717075)
